### PR TITLE
Add configuration migration

### DIFF
--- a/migrate-config
+++ b/migrate-config
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Migrate old Lutris configuration into the snap.
+CONFIG="$SNAP_USER_COMMON/.config"
+SHARE="$SNAP_USER_COMMON/.local/share"
+OLD_CONFIG="$SNAP_REAL_HOME/.config/lutris"
+OLD_SHARE="$SNAP_REAL_HOME/.local/share/lutris"
+src_count=$(find $OLD_CONFIG $OLD_SHARE | wc -l)
+if [ ! -d "$CONFIG/lutris" -a -d "$OLD_CONFIG" -a $src_count -ge 1 ]; then
+    if zenity --question --title "Migrate Lutris Config" --text "Existing Lutris configuration found. Would you like to migrate it to the Snap?"; then
+        mkdir -p "$CONFIG"
+        mkdir -p "$SHARE"
+        cp -Ra "$OLD_CONFIG" "$CONFIG" &
+        cp -Ra "$OLD_SHARE" "$SHARE" &
+
+        (
+            dest_count=0
+            while [ $dest_count -lt $src_count ]; do
+                dest_count=$(find $CONFIG $SHARE | wc -l)
+                echo $(( $dest_count * 100 / $src_count ))
+                sleep 0.1
+            done
+        ) |
+        zenity --progress --title "Lutris Migration" --text "Migrating Lutris configuration..." --percentage=0 --auto-close || exit 1
+        wait
+        if [ "$?" -ne 0 ]; then
+            zenity --error --text="Migration failed. Starting with fresh configuration..." &
+            rm -rf "$CONFIG" "$SHARE"
+            wait
+        fi
+    fi
+fi
+
+# Run the rest of the command chain.
+$@

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -12,6 +12,7 @@ architectures:
     build-for: amd64
 assumes:
   - snapd2.55.4
+  - command-chain
 
 package-repositories:
   - type: apt
@@ -40,6 +41,8 @@ layout:
     symlink: $SNAP/graphics/usr/share/X11/XErrorDB
   /usr/share/X11/locale:
     symlink: $SNAP/graphics/usr/share/X11/locale
+  /usr/share/zenity:
+    bind: $SNAP/usr/share/zenity
  
 environment:
   PYTHONPATH: ${SNAP}/usr/lib/python3/dist-packages:$PYTHONPATH
@@ -48,6 +51,7 @@ environment:
 apps:
   lutris:
     command-chain:
+    - bin/migrate-config
     - bin/graphics-core22-wrapper
     command: usr/bin/lutris
     extensions: [gnome]
@@ -77,6 +81,11 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core22
+  migrate-lutris-config:
+    interface: personal-files
+    read:
+      - $HOME/.config/lutris
+      - $HOME/.local/share/lutris
 
 slots:    
   lutris:
@@ -86,6 +95,18 @@ slots:
   
 
 parts:   
+  migrate-script:
+    plugin: dump
+    source: .
+    stage-packages:
+      - zenity
+    stage:
+      - bin/migrate-config
+      - usr/bin/zenity
+      - usr/share/zenity
+    organize:
+      migrate-config: bin/migrate-config
+
   lutris:
     source: https://github.com/lutris/lutris.git
     after: [lutris-runtime]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,7 +81,7 @@ plugs:
     interface: content
     target: $SNAP/graphics
     default-provider: mesa-core22
-  migrate-lutris-config:
+  lutris-user-config:
     interface: personal-files
     read:
       - $HOME/.config/lutris


### PR DESCRIPTION
This adds a command-chain script which offers new users the ability to migrate their Lutris configuration from where it exists when it was initially installed.

NOTE: This requires the [personal-files interface](https://snapcraft.io/docs/personal-files-interface), which is [super privileged](https://snapcraft.io/docs/super-privileged-interfaces), so this PR should not be merged until the snap has [received the appropriate permissions](https://snapcraft.io/docs/process-for-aliases-auto-connections-and-tracks), as it will prevent the snap from being published in the store.